### PR TITLE
split learning another language into javascript, cont

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -127,7 +127,7 @@ Standards:
         Path: /layout/problem-set-layout.md
   -
     Title: Learning Another Language
-    Description: "Our Path; Hello, World!; FizzBuzz; Summary, Resources, and Next Steps; Semicolons; Variables; Objects; Intro to Functions; Classes; Additional Topics; Problem Set: Intro to JavaScript"
+    Description: "Our Path; Hello, World!; FizzBuzz; Summary, Resources, and Next Steps; Semicolons; Variables; Objects; Intro to Functions; Problem Set: Intro to JavaScript"
     UID: 9199ff6adef8940bbdbaa1cc4649bd9b
     SuccessCriteria:
       - success criteria
@@ -170,6 +170,16 @@ Standards:
         Path: /learning-another-language/intro-to-functions.md
       -
         Type: Lesson
+        UID: 36e4d945
+        Path: /learning-another-language/problem-set-intro-to-javascript.md
+  - Title: Javascript, Cont.
+    Description: "Object-Oriented Classes in Javascript; Writing Javascript Locally; Additional Topics; Activity: Exploring Javascript"
+    UID: c044b5e5-3161-47ec-a1a1-cb55f3b902d9
+    SuccessCriteria:
+      - success criteria
+    ContentFiles:
+      -
+        Type: Lesson
         UID: dc804b1c-8bb0-4b72-95f0-080a3b9b9552
         Path: /learning-another-language/classes.md
       -
@@ -182,12 +192,8 @@ Standards:
         Path: /learning-another-language/additional-topics.md
       -
         Type: Lesson
-        UID: 36e4d945
-        Path: /learning-another-language/problem-set-intro-to-javascript.md
-      -
-        Type: Lesson
         UID: f29ce62d-1fa4-4e88-93af-fb751e2dbb6d
-        Path: /learning-another-language/activity-exploring-javascript.md
+        Path: /learning-another-language/activity-exploring-javascript.md  
   -
     Title: Functions
     Description: "Arrow Functions, Callback Functions, Anonymous Functions, Problem Set: Functions"


### PR DESCRIPTION
- Learning Another Language is very long, so this split moves some of the less fundamental (?) javascript topics to a new topic, "Javascript, Cont"
- Reviewer(s) should double check that the problem set in Learning Another Language doesn't require any content from Javascript, Cont
- Activity was put in the Javascript, Cont topic, but wondering if this would be better in the Learning Another Language topic.
- For C17, this content will be taught during a [4 day week (Monday off)](https://docs.google.com/spreadsheets/d/1mxOQkpnRuEISE45rvlSZBthIXqzj0UUeEtMd0Z6iH_Y/edit#gid=370669079), so this content will likely be all be reviewed on Wednesday. Would love an opinion on whether that is possible, or if we should consider other ways to slice the content.