### PR TITLE
Kp/yarn

### DIFF
--- a/custom-snippets/formatLibrary/Dockerfile
+++ b/custom-snippets/formatLibrary/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /app
 COPY . ./
 
 # Install dependencies
-RUN npm install
+RUN yarn install

--- a/custom-snippets/formatLibrary/package.json
+++ b/custom-snippets/formatLibrary/package.json
@@ -7,7 +7,7 @@
     "test": "jest"
   },
   "author": "",
-  "license": "",
+  "license": "MIT",
   "dependencies": {
     "jest": "^25.4.0"
   }

--- a/custom-snippets/formatLibrary/test.sh
+++ b/custom-snippets/formatLibrary/test.sh
@@ -5,4 +5,4 @@ cp "$submission_file" index.js
 echo >> index.js
 echo "module.exports = formatLibrary" >> index.js
 
-npm test
+yarn test

--- a/custom-snippets/formatReservations/Dockerfile
+++ b/custom-snippets/formatReservations/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /app
 COPY . ./
 
 # Install dependencies
-RUN npm install
+RUN yarn install

--- a/custom-snippets/formatReservations/package.json
+++ b/custom-snippets/formatReservations/package.json
@@ -7,7 +7,7 @@
     "test": "jest"
   },
   "author": "",
-  "license": "",
+  "license": "MIT",
   "dependencies": {
     "jest": "^25.4.0"
   }

--- a/custom-snippets/formatReservations/test.sh
+++ b/custom-snippets/formatReservations/test.sh
@@ -5,4 +5,4 @@ cp "$submission_file" index.js
 echo >> index.js
 echo "module.exports = formatReservations" >> index.js
 
-npm test
+yarn test

--- a/custom-snippets/formatToolList/Dockerfile
+++ b/custom-snippets/formatToolList/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /app
 COPY . ./
 
 # Install dependencies
-RUN npm install
+RUN yarn install

--- a/custom-snippets/formatToolList/package.json
+++ b/custom-snippets/formatToolList/package.json
@@ -7,7 +7,7 @@
     "test": "jest"
   },
   "author": "",
-  "license": "",
+  "license": "MIT",
   "dependencies": {
     "jest": "^25.4.0"
   }

--- a/custom-snippets/formatToolList/test.sh
+++ b/custom-snippets/formatToolList/test.sh
@@ -5,4 +5,4 @@ cp "$submission_file" index.js
 echo >> index.js
 echo "module.exports = formatToolList" >> index.js
 
-npm test
+yarn test

--- a/custom-snippets/giveGreetingChallenge/Dockerfile
+++ b/custom-snippets/giveGreetingChallenge/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /app
 COPY . ./
 
 # Install dependencies
-RUN npm install
+RUN yarn install

--- a/custom-snippets/giveGreetingChallenge/package.json
+++ b/custom-snippets/giveGreetingChallenge/package.json
@@ -7,7 +7,7 @@
     "test": "jest"
   },
   "author": "",
-  "license": "",
+  "license": "MIT",
   "dependencies": {
     "jest": "^25.4.0"
   }

--- a/custom-snippets/giveGreetingChallenge/test.sh
+++ b/custom-snippets/giveGreetingChallenge/test.sh
@@ -5,4 +5,4 @@ cp "$submission_file" submission.js
 echo >> submission.js
 echo "module.exports = {giveCasualGreeting, giveFormalGreeting, writeLetter};" >> submission.js
 
-npm test
+yarn test

--- a/custom-snippets/isOddNumber/Dockerfile
+++ b/custom-snippets/isOddNumber/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /app
 COPY . ./
 
 # Install dependencies
-RUN npm install
+RUN yarn install

--- a/custom-snippets/isOddNumber/package.json
+++ b/custom-snippets/isOddNumber/package.json
@@ -7,7 +7,7 @@
     "test": "jest"
   },
   "author": "",
-  "license": "",
+  "license": "MIT",
   "dependencies": {
     "jest": "^25.4.0"
   }

--- a/custom-snippets/isOddNumber/test.sh
+++ b/custom-snippets/isOddNumber/test.sh
@@ -5,4 +5,4 @@ cp "$submission_file" submission.js
 echo >> submission.js
 echo "module.exports = isOddNumber;" >> submission.js
 
-npm test
+yarn test

--- a/custom-snippets/mystery/Dockerfile
+++ b/custom-snippets/mystery/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /app
 COPY . ./
 
 # Install dependencies
-RUN npm install
+RUN yarn install

--- a/custom-snippets/mystery/package.json
+++ b/custom-snippets/mystery/package.json
@@ -7,7 +7,7 @@
     "test": "jest"
   },
   "author": "",
-  "license": "",
+  "license": "MIT",
   "dependencies": {
     "jest": "^25.4.0"
   }

--- a/custom-snippets/mystery/test.sh
+++ b/custom-snippets/mystery/test.sh
@@ -4,4 +4,4 @@ submission_file=${1:-submission.txt}
 cp "$submission_file" mystery.js
 echo "module.exports = mystery" >> mystery.js
 
-npm test
+yarn test

--- a/custom-snippets/reservation/Dockerfile
+++ b/custom-snippets/reservation/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /app
 COPY . ./
 
 # Install dependencies
-RUN npm install
+RUN yarn install

--- a/custom-snippets/reservation/package.json
+++ b/custom-snippets/reservation/package.json
@@ -7,7 +7,7 @@
     "test": "jest"
   },
   "author": "",
-  "license": "",
+  "license": "MIT",
   "dependencies": {
     "jest": "^25.4.0"
   }

--- a/custom-snippets/reservation/test.sh
+++ b/custom-snippets/reservation/test.sh
@@ -5,4 +5,4 @@ cp "$submission_file" submission.js
 echo >> index.js
 echo "module.exports = {Reservation};" >> submission.js
 
-npm test
+yarn test

--- a/custom-snippets/summarizeLibrary/Dockerfile
+++ b/custom-snippets/summarizeLibrary/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /app
 COPY . ./
 
 # Install dependencies
-RUN npm install
+RUN yarn install

--- a/custom-snippets/summarizeLibrary/package.json
+++ b/custom-snippets/summarizeLibrary/package.json
@@ -7,7 +7,7 @@
     "test": "jest"
   },
   "author": "",
-  "license": "",
+  "license": "MIT",
   "dependencies": {
     "jest": "^25.4.0"
   }

--- a/custom-snippets/summarizeLibrary/test.sh
+++ b/custom-snippets/summarizeLibrary/test.sh
@@ -5,4 +5,4 @@ cp "$submission_file" submission.js
 echo >> index.js
 echo "module.exports = {Tool, ToolLibrary, Reservation};" >> submission.js
 
-npm test
+yarn test

--- a/custom-snippets/tool/Dockerfile
+++ b/custom-snippets/tool/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /app
 COPY . ./
 
 # Install dependencies
-RUN npm install
+RUN yarn install

--- a/custom-snippets/tool/package.json
+++ b/custom-snippets/tool/package.json
@@ -7,7 +7,7 @@
     "test": "jest"
   },
   "author": "",
-  "license": "",
+  "license": "MIT",
   "dependencies": {
     "jest": "^25.4.0"
   }

--- a/custom-snippets/tool/test.sh
+++ b/custom-snippets/tool/test.sh
@@ -5,4 +5,4 @@ cp "$submission_file" submission.js
 echo >> index.js
 echo "module.exports = {Tool};" >> submission.js
 
-npm test
+yarn test

--- a/custom-snippets/toolLibrary/Dockerfile
+++ b/custom-snippets/toolLibrary/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /app
 COPY . ./
 
 # Install dependencies
-RUN npm install
+RUN yarn install

--- a/custom-snippets/toolLibrary/package.json
+++ b/custom-snippets/toolLibrary/package.json
@@ -7,7 +7,7 @@
     "test": "jest"
   },
   "author": "",
-  "license": "",
+  "license": "MIT",
   "dependencies": {
     "jest": "^25.4.0"
   }

--- a/custom-snippets/toolLibrary/test.sh
+++ b/custom-snippets/toolLibrary/test.sh
@@ -5,4 +5,4 @@ cp "$submission_file" submission.js
 echo >> index.js
 echo "module.exports = {ToolLibrary};" >> submission.js
 
-npm test
+yarn test


### PR DESCRIPTION
**Summary of Changes**
- Change `npm` to `yarn` for testing
   - running tests with npm in Learn seems to use an outdated version of `npm` and leads to a lot of warning message that clutters up the test output
- Add value to `license` key in `package.json` to eliminate warning message


**For review**
- Very tedious, but run the tests for all coding challenges in Unit 3 problem sets to confirm that there are no errors with testing, tests use yarn, and no warning messages are included in output
- Docker and learn preview continue to give me issues. To see the lesson on Learn go to Ada Core Sandbox > Setup and set the branch to `kp/yarn` for the `core-unit-3` repo. 